### PR TITLE
Добавил конфиги для линтеров

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,10 @@
+[flake8]
+docstring-convention=numpy
+ignore =
+    # ingnore blank line separator rule on long one-line docstrings
+    D205
+    # ignore period rule on one-line docstrings
+    D400
+per-file-ignores =
+    # ignore warnings about .next() because this is FSMContext method
+    persistence/main.py:B305

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,6 @@
+[tool.black]
+line-length = 79
+
 [tool.poetry]
 name = "persistence"
 version = "0.1.0"


### PR DESCRIPTION
Данные настройки работают как для локального использования `poetry run black/flake8`, так и для pre-commit. Для black поставил максимальную длину строки - 79, для flake8 указал соглашение о докстрингах (у нампая она самая щадящая), максимальную сложность (коротко - для того, чтобы функции и куски кода не были слишком сложными или nested), и конкретные ошибки для замалчивания (в комментах объяснено почему)