### PR TITLE
Добавил flake8-import-order в pre-commit

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,6 +1,7 @@
 [flake8]
 docstring-convention=numpy
 max-complexity = 8
+import_order_style = smarkets
 ignore =
     # ingnore blank line separator rule on long one-line docstrings
     D205

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,4 +11,5 @@ repos:
     - flake8-bugbear
     - flake8-comprehensions
     - flake8-docstrings
+    - flake8-import-order
     - pep8-naming

--- a/poetry.lock
+++ b/poetry.lock
@@ -220,6 +220,18 @@ flake8 = ">=3"
 pydocstyle = ">=2.1"
 
 [[package]]
+name = "flake8-import-order"
+version = "0.18.1"
+description = "Flake8 and pylama plugin that checks the ordering of import statements."
+category = "dev"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+pycodestyle = "*"
+setuptools = "*"
+
+[[package]]
 name = "flake8-polyfill"
 version = "1.0.2"
 description = "Polyfill package for Flake8 plugins"
@@ -566,7 +578,7 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "eb294f8284b443a735a4e5b72b11d441004439a85bb3b633ec91459f6f938dc4"
+content-hash = "5bdfb2394106bf566e5a9c6d691028641d1d5bf9685d52fccd4d7b1c6d7ba578"
 
 [metadata.files]
 aiogram = [
@@ -679,6 +691,10 @@ flake8-comprehensions = [
 flake8-docstrings = [
     {file = "flake8-docstrings-1.6.0.tar.gz", hash = "sha256:9fe7c6a306064af8e62a055c2f61e9eb1da55f84bb39caef2b84ce53708ac34b"},
     {file = "flake8_docstrings-1.6.0-py2.py3-none-any.whl", hash = "sha256:99cac583d6c7e32dd28bbfbef120a7c0d1b6dde4adb5a9fd441c4227a6534bde"},
+]
+flake8-import-order = [
+    {file = "flake8-import-order-0.18.1.tar.gz", hash = "sha256:a28dc39545ea4606c1ac3c24e9d05c849c6e5444a50fb7e9cdd430fc94de6e92"},
+    {file = "flake8_import_order-0.18.1-py2.py3-none-any.whl", hash = "sha256:90a80e46886259b9c396b578d75c749801a41ee969a235e163cfe1be7afd2543"},
 ]
 flake8-polyfill = [
     {file = "flake8-polyfill-1.0.2.tar.gz", hash = "sha256:e44b087597f6da52ec6393a709e7108b2905317d0c0b744cdca6208e670d8eda"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ flake8 = "^3.9.2"
 flake8-docstrings = "^1.6.0"
 flake8-bugbear = "^21.4.3"
 flake8-comprehensions = "^3.5.0"
+flake8-import-order = "^0.18.1"
 pep8-naming = "^0.12.0"
 
 [tool.poetry.scripts]


### PR DESCRIPTION
## Кратко об изменениях
Добавил flake8-import-order в pre-commit и зависимости проекта. Добавил для него опцию в конфиге.

## Обоснование
До этого коммита в проекте не было линтера для импортов. Особенно импортный ужас творится в файле main.py (файл с ботом), там он точно поможет выстроить правильный порядок.

Я также рассматривал isort (flake8-isort), но мне он не понравился своей категоричностью, это скорее black для импортов, и в этом он хуже.

## Подробности
Добавил flake8-import-order в хуки pre-commit. Добавил flake8-import-order в зависимости проекта (pyproject.toml) и обновил лок. Добавил одну настройку для данного хука - конкретный стиль расположения импортов (smarkets), оставлю ниже ссылку на пример, как при нём должны выглядеть импорты.

## Необходимое пояснение
1) pre-commit сам создаст окружение под новый хук при первом же коммите.
2) О возможных стилях для flake8-import-order [тут](https://github.com/PyCQA/flake8-import-order#styles), пример того, как выглядят импорты при стиле smarkets - [тут](https://github.com/PyCQA/flake8-import-order/blob/master/tests/test_cases/complete_smarkets.py)
