### PR TITLE
Исправил абсолютные импорты

### DIFF
--- a/persistence/main.py
+++ b/persistence/main.py
@@ -12,6 +12,8 @@ from .vacancies import direction
 from .reports import report
 from . import about_company as ac
 from .support import BOT_SUPPORT
+from .stock import stocks
+from .history import history_of_severstal
 
 logging.basicConfig(level=logging.INFO)
 
@@ -81,8 +83,6 @@ async def send_report(message: types.Message, state: FSMContext):
 
 @dp.message_handler(TextFilter(equals=kb.stock), state="*")
 async def send_stock(message: types.Message):
-    from stock import stocks
-
     await message.answer(stocks())
 
 
@@ -93,8 +93,6 @@ async def send_info_about_campany(message: types.Message):
 
 @dp.message_handler(TextFilter(equals=kb.history), state="*")
 async def send_history(message):
-    from history import history_of_severstal
-
     await message.answer(history_of_severstal())
 
 


### PR DESCRIPTION
<!--- Надеемся, что перед этим вы прочитали наш [гайд для контрибьютеров](https://github.com/bullbesh/persistence/CONTRIBUTING.md)  -->
<!--- Назовите пулл-реквест как общий итог всех ваших изменений (начиная с глагола Добавил/Изменил/Удалил) -->

## Кратко об изменениях
<!--- В нескольких словах об изменениях -->
Исправил абсолютные импорты, заменив их на относительные

## Обоснование
<!--- Почему нужны эти изменения? -->
При переходе на poetry, все файлы были перенесены в свою папку, и нуждались в исправлении импортов на относительные (`from stock import stock` -> `from .stock import stock`). Эти импорты были вложенными (не имея оснований каких-то), и я пропустил их при первом исправлении

## Подробности
<!--- Очень подробно об изменениях - все шаги, все неочевидные детали -->
Изменил абсолютные импорты на относительные, перенёс их в секции импортов, избавившись от импортов внутри функций бота

## Необходимое пояснение
<!--- Если нужны какие-то пояснения, например - ссылка на что-либо или объяснение сути нового инструмента/библиотеки -->
