### PR TITLE
Удалил подсказки типов из сигнатур функций

### DIFF
--- a/persistence/main.py
+++ b/persistence/main.py
@@ -34,7 +34,7 @@ class capital_or_report(StatesGroup):
 
 
 @dp.message_handler(commands=["start"], state="*")
-async def send_welcome(message: types.Message):
+async def send_welcome(message):
     await message.answer(
         "Бот, предоставяющий информацию о предприятии Северсталь.\n\nДля ознакомления с функциями "
         "нажмите на кнопку 'Помощь'",
@@ -48,12 +48,12 @@ async def send_help(message):
 
 
 @dp.message_handler(TextFilter(equals=kb.FINANCIAL_PERFORMANCE), state="*")
-async def send_financial_summary(message: types.Message):
+async def send_financial_summary(message):
     await message.answer("Выберите раздел", reply_markup=kb.markupF)
 
 
 @dp.message_handler(TextFilter(equals=kb.FINANCIAL_STATEMENTS), state="*")
-async def send_report_info(message: types.Message, state: FSMContext):
+async def send_report_info(message, state):
     await capital_or_report.choice.set()
     await message.answer("Выберите отчёт", reply_markup=kb.report_markup)
 
@@ -63,7 +63,7 @@ async def send_report_info(message: types.Message, state: FSMContext):
     in ["Общий доход компании", "Акционерный капитал", "Чистая прибыль"],
     state=capital_or_report.choice,
 )
-async def send_period(message: types.Message, state: FSMContext):
+async def send_period(message, state):
     async with state.proxy() as data:
         data["choice"] = message.text
     await capital_or_report.next()
@@ -74,7 +74,7 @@ async def send_period(message: types.Message, state: FSMContext):
     lambda message: message.text in ["Квартальный отчёт", "Годовой отчёт"],
     state=capital_or_report.period,
 )
-async def send_report(message: types.Message, state: FSMContext):
+async def send_report(message, state):
     async with state.proxy() as data:
         data["period"] = message.text
     await message.answer(
@@ -83,12 +83,12 @@ async def send_report(message: types.Message, state: FSMContext):
 
 
 @dp.message_handler(TextFilter(equals=kb.BUTTON_STOCK_PRICE), state="*")
-async def send_stock(message: types.Message):
+async def send_stock(message):
     await message.answer(stocks())
 
 
 @dp.message_handler(TextFilter(equals=kb.ABOUT_COMPANY), state="*")
-async def send_company_info(message: types.Message):
+async def send_company_info(message):
     await message.answer(ac.SHORT_DESCRIPTION, parse_mode=types.message.ParseMode.MARKDOWN, reply_markup=kb.company_markup)
 
 
@@ -98,51 +98,51 @@ async def send_history(message):
 
 
 @dp.message_handler(TextFilter(equals=kb.COMPANY_STRUCTURE), state="*")
-async def send_structure(message: types.Message):
+async def send_structure(message):
     await message.answer("Выберите раздел", reply_markup=kb.markup_structure)
 
 
 @dp.message_handler(TextFilter(equals=kb.SEVERSTAL_RUSSIAN_STEEL), state="*")
-async def send_structure(message: types.Message):
+async def send_structure(message):
     await message.answer(
         ac.SEVERSTAL_RUSSIAN_STEEL, reply_markup=kb.company_markup
     )
 
 
 @dp.message_handler(TextFilter(equals=kb.SEVERSTAL_RESOURCE), state="*")
-async def send_severstal_russian_steel(message: types.Message):
+async def send_severstal_russian_steel(message):
     await message.answer(ac.SEVERSTAL_RESOURCE, reply_markup=kb.company_markup)
 
 
 @dp.message_handler(TextFilter(equals=kb.COMPANY_KEY_ASSETS), state="*")
-async def send_key_assets(message: types.Message):
+async def send_key_assets(message):
     await message.answer(ac.COMPANY_KEY_ASSETS, reply_markup=kb.company_markup)
 
 
 @dp.message_handler(TextFilter(equals=kb.TRADING_COMPANIES), state="*")
-async def send_trading_companies(message: types.Message):
+async def send_trading_companies(message):
     await message.answer(ac.TRADING_COMPANIES, reply_markup=kb.company_markup)
 
 
 @dp.message_handler(TextFilter(equals=kb.FURTHER_REDISTRIBUTION_ENTERPRISES), state="*")
-async def send_further_redistribution_enterprises(message: types.Message):
+async def send_further_redistribution_enterprises(message):
     await message.answer(
         ac.FURTHER_REDISTRIBUTION_ENTERPRISES, reply_markup=kb.company_markup
     )
 
 
 @dp.message_handler(TextFilter(equals=kb.OTHER_ENTERPRISES), state="*")
-async def send_other_businesses(message: types.Message):
+async def send_other_businesses(message):
     await message.answer(ac.OTHER_ENTERPRISES, reply_markup=kb.company_markup)
 
 
 @dp.message_handler(TextFilter(equals=kb.STRATEGY_AND_STRATEGIC_PRIORITIES), state="*")
-async def send_strategy(message: types.Message):
+async def send_strategy(message):
     await message.answer(ac.COMPANY_STARTEGY, parse_mode=types.message.ParseMode.MARKDOWN, reply_markup=kb.company_markup)
 
 
 @dp.message_handler(TextFilter(equals=kb.COMPANY_LEADERSHIP), state="*")
-async def send_leadership(message: types.Message):
+async def send_leadership(message):
     await message.answer(
         "Выберите тип руководства", reply_markup=kb.leadership_markup
     )
@@ -151,19 +151,19 @@ async def send_leadership(message: types.Message):
 @dp.message_handler(
     TextFilter(equals=kb.SEVERSTAL_MANAGEMENT_DIRECTION), state="*"
 )
-async def send_severstal_management_direction(message: types.Message):
+async def send_severstal_management_direction(message):
     await message.answer(
         ac.SEVERSTAL_MANAGEMENT_DIRECTION, reply_markup=kb.company_markup
     )
 
 
 @dp.message_handler(TextFilter(equals=kb.ENTERPRISE_MANAGEMENT), state="*")
-async def send_enterprise_management(message: types.Message):
+async def send_enterprise_management(message):
     await message.answer(ac.ENTERPRISE_MANAGEMENT, reply_markup=kb.company_markup)
 
 
 @dp.message_handler(TextFilter(equals=kb.DIRECTORS_MEMBERS_BOARD), state='*')
-async def send_board_members(message: types.Message):
+async def send_board_members(message):
     await message.answer(ac.DIRECTORS_MEMBERS_BOARD, reply_markup=kb.company_markup)
 
 
@@ -178,7 +178,7 @@ async def send_direction(message):
     in ["Производство", "IT & Digital", "Офис", "Молодым специалистам"],
     state=vaca.vacation,
 )
-async def send_vacationM(message: types.Message, state: FSMContext):
+async def send_vacationM(message, state):
     async with state.proxy() as data:
         data["vacation"] = message.text
     await vaca.next()
@@ -186,7 +186,7 @@ async def send_vacationM(message: types.Message, state: FSMContext):
 
 
 @dp.message_handler(lambda message: message.text in kb.CITIES_LIST, state=vaca.city)
-async def send_vactions(message: types.Message, state: FSMContext):
+async def send_vactions(message, state):
     async with state.proxy() as data:
         data["city"] = message.text
     await message.answer(
@@ -195,17 +195,17 @@ async def send_vactions(message: types.Message, state: FSMContext):
 
 
 @dp.message_handler(TextFilter(equals=kb.BUTTON_BACK), state="*")
-async def go_back(message: types.Message):
+async def go_back(message):
     await message.answer("Хорошо", reply_markup=kb.markup1)
 
 
 @dp.message_handler(TextFilter(equals=kb.BUTTON_HELP), state="*")
-async def send_help(message: types.Message, state="*"):
+async def send_help(message, state="*"):
     await message.answer(BOT_SUPPORT, parse_mode=types.message.ParseMode.MARKDOWN, reply_markup=kb.markup1)
 
 
 @dp.message_handler()
-async def send_error(message: types.Message, state='*'):
+async def send_error(message, state='*'):
     await message.answer(bold("Используйте навигационные кнопки!"), parse_mode=types.ParseMode.MARKDOWN_V2)
 
 


### PR DESCRIPTION
<!--- Надеемся, что перед этим вы прочитали наш [гайд для контрибьютеров](https://github.com/bullbesh/persistence/CONTRIBUTING.md)  -->
<!--- Назовите пулл-реквест как общий итог всех ваших изменений (начиная с глагола Добавил/Изменил/Удалил) -->

## Кратко об изменениях
<!--- В нескольких словах об изменениях -->
Удалил все аннотации типов из функций

## Обоснование
<!--- Почему нужны эти изменения? -->
Аннотации типов присутствуют только в файле main.py, хотя должны быть либо везде, либо нигде. Также они удлиняют код (конкретно в боте) и не несут полезной информации (всего три разных аннотации на весь файл, аргументы у хэндлеров сообщений везде одинаковые)

## Подробности
<!--- Очень подробно об изменениях - все шаги, все неочевидные детали -->
Убрал аннотации типов у аргументов функций файлы main.py . Всё было сделано тем же инструментом из #13. Команда - `red "([[:alpha:]]+): ([a-zA-Z\.]+)(\)|,)" "$1$3" persistence\main.py`, как видно - была применена только к файлу main.py .

Так как были убраны аннотации типов, появились неиспользуемые импорты. Их я не трогал, их уберёт @bullbesh в своём скором ПР на исправление файлов под соответствие хукам из pre-commit :grin: 

## Необходимое пояснение
<!--- Если нужны какие-то пояснения, например - ссылка на что-либо или объяснение сути нового инструмента/библиотеки -->